### PR TITLE
Fix case issue on the package namespace + gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logentries Hook for [Logrus](https://github.com/Sirupsen/logrus)
+# Logentries Hook for [Logrus](https://github.com/sirupsen/logrus)
 
 Package logentriesrus provides a logentries hook for the [logrus] logging package.
 
@@ -10,7 +10,7 @@ package main
 import (
     "os"
 
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/jcftang/logentriesrus"
 )
 

--- a/example/example.go
+++ b/example/example.go
@@ -1,28 +1,27 @@
 package main
 
 import (
-    "os"
+	"os"
 
-    "github.com/Sirupsen/logrus"
-    "github.com/jcftang/logentriesrus"
+	"github.com/jcftang/logentriesrus"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 
-    logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 
-    logrus.SetOutput(os.Stderr)
+	logrus.SetOutput(os.Stderr)
 
-    logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.DebugLevel)
 
-    le, err := logentriesrus.NewLogentriesrusHook("5605593B-9E4F-4A3E-9865-12752055E14B")
-    if err != nil {
-        os.Exit(-1)        
-    }
-    logrus.AddHook(le)
+	le, err := logentriesrus.NewLogentriesrusHook("5605593B-9E4F-4A3E-9865-12752055E14B")
+	if err != nil {
+		os.Exit(-1)
+	}
+	logrus.AddHook(le)
 
-    logrus.WithFields(logrus.Fields{"foo": "bar", "foo2": 42}).Warn("this is a warn level message")
-    logrus.Info("this is an info level message")
-    logrus.Debug("this is a debug level message")
+	logrus.WithFields(logrus.Fields{"foo": "bar", "foo2": 42}).Warn("this is a warn level message")
+	logrus.Info("this is an info level message")
+	logrus.Debug("this is a debug level message")
 }
-

--- a/levels.go
+++ b/levels.go
@@ -1,24 +1,24 @@
 package logentriesrus
 
 import (
-    "github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var AllLevels = []logrus.Level{
-    logrus.DebugLevel,
-    logrus.InfoLevel,
-    logrus.WarnLevel,
-    logrus.ErrorLevel,
-    logrus.FatalLevel,
-    logrus.PanicLevel,
+	logrus.DebugLevel,
+	logrus.InfoLevel,
+	logrus.WarnLevel,
+	logrus.ErrorLevel,
+	logrus.FatalLevel,
+	logrus.PanicLevel,
 }
 
 // Returns every logging level above and including the given parameter.
 func LevelThreshold(l logrus.Level) []logrus.Level {
-    for i := range AllLevels {
-        if AllLevels[i] == l {
-            return AllLevels[i:]
-        }
-    }
-    return []logrus.Level{}
+	for i := range AllLevels {
+		if AllLevels[i] == l {
+			return AllLevels[i:]
+		}
+	}
+	return []logrus.Level{}
 }

--- a/logentriesrus.go
+++ b/logentriesrus.go
@@ -1,44 +1,44 @@
 package logentriesrus
 
 import (
-    "fmt"
-    "os"
-    "github.com/Sirupsen/logrus"
-    "github.com/bsphere/le_go"
+	"fmt"
+	"github.com/bsphere/le_go"
+	"github.com/sirupsen/logrus"
+	"os"
 )
 
 // Project version
 const (
-        VERISON = "0.0.1"
+	VERISON = "0.0.1"
 )
 
 type LogentriesrusHook struct {
-    AcceptedLevels []logrus.Level
-    Client *le_go.Logger
+	AcceptedLevels []logrus.Level
+	Client         *le_go.Logger
 }
 
 func NewLogentriesrusHook(t string) (*LogentriesrusHook, error) {
-    client, err := le_go.Connect(t)
-    le := LogentriesrusHook{
-        Client: client,
-    }
-    return &le, err
+	client, err := le_go.Connect(t)
+	le := LogentriesrusHook{
+		Client: client,
+	}
+	return &le, err
 }
 
 func (l *LogentriesrusHook) Fire(e *logrus.Entry) error {
-    line, err := e.String()
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
-        return err
-    }
+	line, err := e.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
+		return err
+	}
 
-    l.Client.Println(line)
-    return nil
+	l.Client.Println(line)
+	return nil
 }
 
 func (l *LogentriesrusHook) Levels() []logrus.Level {
-        if l.AcceptedLevels == nil {
-                return AllLevels
-        }
-        return l.AcceptedLevels
+	if l.AcceptedLevels == nil {
+		return AllLevels
+	}
+	return l.AcceptedLevels
 }


### PR DESCRIPTION
As the logrus package advise in the README: https://github.com/sirupsen/logrus

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.

This fixes issues like : 

```
case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"
```

Also gofmt has been run to comply with Go code style